### PR TITLE
Refresh Maven configuration and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,47 @@
-Дано два потока — производитель и потребитель. Производитель генерирует некоторые данные (как пример — числа). Производитель «потребляет» их.
-Два потока разделяют общий буфер данных, размер которого ограничен. Если буфер пуст, потребитель должен ждать, пока там появятся данные. 
-Если буфер заполнен полностью, производитель должен ждать, пока потребитель заберёт данные и место освободится.
+# producerConsumer
+
+`producerConsumer` is a small Java project that demonstrates several implementations of the classic producer-consumer problem with a bounded shared buffer.
+
+## What It Shows
+
+Two kinds of worker threads share a limited buffer:
+
+- a producer generates data items
+- a consumer reads data items from the buffer
+
+If the buffer is empty, the consumer must wait. If the buffer is full, the producer must wait until space becomes available.
+
+## Project Structure
+
+- `basicRealization` - a basic thread-based implementation
+- `anotherRealization` - an alternative thread-based implementation
+- `executorsRealization` - an implementation based on `ExecutorService`
+- `concurrentSingleton` - several singleton examples for concurrent environments
+
+## Build
+
+Compile the project with Maven:
+
+```bash
+mvn clean package
+```
+
+## Run
+
+Each package contains its own `Demo` entry point. For example, you can run one of them from your IDE or by executing the compiled classes after packaging.
+
+The most illustrative starting points are:
+
+- `basicRealization.Demo`
+- `anotherRealization.Demo`
+- `executorsRealization.Demo`
+
+## Verification
+
+The repository can be checked with:
+
+```bash
+mvn test
+```
+
+As of Monday, August 17, 2026, this command completes with `BUILD SUCCESS`, and Maven reports that there are no automated tests to run.

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,39 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>8</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
## What changed
- refreshed the Maven build configuration and pinned plugin versions
- switched the project to explicit `UTF-8` source and reporting encodings
- replaced separate `source` and `target` settings with `maven.compiler.release=8`
- rewrote the README in English with a short overview of the producer-consumer implementations and runnable entry points

## Why
The project already compiled, but its Maven setup depended on the platform default encoding and left plugin versions implicit. That makes the build less reproducible across machines. The repository documentation also only existed in Russian and did not explain the different implementations clearly for English-speaking readers.

## Validation
- ran `mvn test` on Monday, August 17, 2026
- result: `BUILD SUCCESS`
- note: the repository currently has no automated tests, so Maven reported `No tests to run`

## Impact
- the build is more predictable on different environments
- repository onboarding is clearer
- the code structure is easier to understand before opening the demos